### PR TITLE
Added style transform based on phloc-css

### DIFF
--- a/src/enliven/html/util.clj
+++ b/src/enliven/html/util.clj
@@ -1,0 +1,37 @@
+(ns enliven.html.util)
+
+(defn ord-hash [contents]
+  (let [contents (seq contents)]
+    (reify                   
+      clojure.lang.IPersistentMap
+      (assoc [_ k v]
+        (ord-hash (cons [k v] (filter (fn [[ky _]] (not= k ky)) contents))))
+      (assocEx [_ k v]
+        (if (some (fn [[ky _]] (= k ky)) contents)
+          (throw (Exception. ("Key already present"))) 
+          (ord-hash (cons [k v] contents))))
+      (without [_ k]
+        (ord-hash (filter (fn [[ky _]] (not= k ky)) contents)))
+
+      clojure.lang.ILookup
+      (valAt [_ k] (some (fn [[ky _]] (= k ky)) contents))
+      (valAt [_ k not-found] (or (some (fn [[ky _]] (= k ky)) contents)
+                                 not-found))
+      clojure.lang.Seqable
+      (seq [_]
+        (.seq contents))
+      
+      java.lang.Iterable
+      (iterator [this]
+        (.iterator contents))
+      
+      clojure.lang.Associative
+      (containsKey [_ k]
+        (.containsKey (boolean (some (fn [[ky _]] (= k ky)) contents))))
+      (entryAt [_ k]
+        (.entryAt (let [el (some (fn [[ky _]] (= k ky)) contents)]
+                    (when el (second el)))))
+      
+      clojure.lang.Counted
+      (count [_]
+        (.count contents)))))

--- a/test/enliven/html_test.clj
+++ b/test/enliven/html_test.clj
@@ -2,7 +2,7 @@
   (:use clojure.test)
   (:require 
    [enliven.html :as h :refer [static-template content class
-                               append prepend]]
+                               append prepend style]]
    [enliven.html.jsoup :as jsoup]
    [enliven.core.locs :as loc]
    [enliven.core.segments :as seg]))
@@ -38,6 +38,7 @@
 (def node (jsoup/parse "<div>"))
 (def node2 (jsoup/parse "<div><span>t</span></div>"))
 (def node3 (jsoup/parse "<ul><li><span class=a></span><span class=b></span>"))
+(def node4 (jsoup/parse "<div style='background-color:green;color:blue;'>"))
 
 (defn page-wrap [node-str]
   (str "<html><head></head><body>" node-str "</body></html>"))
@@ -59,6 +60,15 @@
     (let [trans (static-template node2 :div (prepend :success))]
       (is (= (page-wrap "<div>test<span>t</span></div>")
              (trans {:success "test"})))))
+   (testing "style tranform - insert style"
+    (let [trans (static-template node :div (style :color :color))]
+      (is (= (page-wrap "<div style='color:red;'></div>")
+             (trans {:color "red"})))))
+   (testing "style tranform - update style"
+     (let [trans (static-template node4 :div (style :background-color
+                                                    :color))]
+      (is (= (page-wrap "<div style='color:blue;background-color:red;'></div>")
+             (trans {:color "red"})))))
    (testing "dup tranform"
     (let [trans (static-template node :div (h/dup :items (content [])))]
       (is (= (page-wrap "<div>0</div><div>1</div><div>2</div>")


### PR DESCRIPTION
I choose to implement an ordered-hash because I didn't want to carry any state in the styles segment.  I also think if we want to do transformations on css stylesheets the ordered hash will make this a lot easier.  It obviously has linear access so its only for small data sets.  That should be fine for style attributes and even style sheets.
